### PR TITLE
Refatorando rotas

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { ROUTING } from './app.routes';
+import { AppRouting } from './app.routes';
 import { HttpClientModule, HttpClient } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -18,6 +18,7 @@ import { SpeciesComponent } from './species/species.component';
 import { PlanetsComponent } from './planets/planets.component';
 import { CharacteristicsComponent } from './components/characteristics/characteristics.component';
 import { NameComponent } from './components/name/name.component';
+import { ShellComponent } from './shell/shell.component';
 
 @NgModule({
   declarations: [
@@ -33,12 +34,13 @@ import { NameComponent } from './components/name/name.component';
     SpeciesComponent,
     PlanetsComponent,
     CharacteristicsComponent,
-    NameComponent
+    NameComponent,
+    ShellComponent
   ],
   imports: [
     BrowserModule,
     HttpClientModule,
-    ROUTING,
+    AppRouting,
     BrowserAnimationsModule
   ],
   providers: [DataService],

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,7 @@
+import { ShellComponent } from './shell/shell.component';
+import { NgModule } from '@angular/core';
+
 import { RouterModule, Routes } from '@angular/router';
-import { ModuleWithProviders } from '@angular/core/src/metadata/ng_module';
 import { CategoriesComponent } from './categories/categories.component';
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './header/header.component';
@@ -9,14 +11,31 @@ import { VehiclesComponent } from './vehicles/vehicles.component';
 import { SpeciesComponent } from './species/species.component';
 import { PlanetsComponent } from './planets/planets.component';
 
-export const AppRoutes: Routes = [
-  { path: 'starwars', component: HeaderComponent },
-  { path: 'starwars/categories', component: CategoriesComponent },
-  { path: 'starwars/people', component: PeopleComponent },
-  { path: 'starwars/starships', component: StarshipsComponent },
-  { path: 'starwars/vehicles', component: VehiclesComponent },
-  { path: 'starwars/species', component: SpeciesComponent },
-  { path: 'starwars/planets', component: PlanetsComponent },
+const children: Routes = [
+  { path: '', component: HeaderComponent },
+  { path: 'categories', component: CategoriesComponent },
+  { path: 'people', component: PeopleComponent },
+  { path: 'starships', component: StarshipsComponent },
+  { path: 'vehicles', component: VehiclesComponent },
+  { path: 'species', component: SpeciesComponent },
+  { path: 'planets', component: PlanetsComponent },
 ];
 
-export const ROUTING: ModuleWithProviders = RouterModule.forRoot(AppRoutes);
+const AppRoutes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: 'starwars'
+  },
+  {
+    path: 'starwars',
+    component: ShellComponent,
+    children
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(AppRoutes)],
+  exports: [RouterModule],
+})
+export class AppRouting { }

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'sw-shell',
+  template: `
+    <router-outlet></router-outlet>
+  `,
+  styles: []
+})
+export class ShellComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
Uma simples refatoração para deixar escalável. 

Além disso, é mais usual usar ngmodules pra rotas do que o modulwithproviders. Ele era utilizado back in Angular 2 e algumas boas praticas sugerem que utilize o ngmodule. [Ver doc](https://angular.io/guide/router#configuration). Com isso ainda se pode colocar as rotas filhas dentro de seus propios componentes e exportar pra o app routes :)  